### PR TITLE
Center NFC tag indention

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -95,6 +95,9 @@ class BaseTag3D {
       if (this.options.base.nfcIndentationHidden) {
         holeMesh.position.z += 1;
       }
+
+      holeMesh.position.x = baseMesh.position.x;
+
       holeMesh.updateMatrix();
 
       baseMesh = subtractMesh(baseMesh, holeMesh);


### PR DESCRIPTION
The NFC tag indention was centered on the position of the base without text.
Hence, it was not possible to create a tag indention larger than the base height, even if the whole model was large enought after text was added.

Not the NFC tag indention is centered on the whole model, which looks nicer and supports the situation mentioned above.